### PR TITLE
Improve Atom startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.5"
   },
+  "activationHooks": ["language-html:grammar-used"],
   "readme": "# Atom HTML Preview\n\nA live preview tool for Atom Editor.\n\nInstall:\n```bash\napm install atom-html-preview\n```\n\nToogle HTML Preview:\n\nPress `CTRL-P` in editor to open Preview.\n\n![Atom HTML Preview](https://dl.dropboxusercontent.com/u/20947008/webbox/atom/atom-html-preview.png)\n\nAn example with [Twitter Bootstrap 3 Package][1]\n\n![Atom HTML Preview with Bootstrap](https://dl.dropboxusercontent.com/u/20947008/webbox/atom/atom-bootstrap-3.gif)\n\n[1]: http://atom.io/packages/atom-bootstrap3\n",
   "readmeFilename": "README.md",
   "bugs": {


### PR DESCRIPTION
Don't activate until the user actually opens an HTML file.

This saves Atom about 40ms of startup time.

For more details, search for `activationHooks` on
http://flight-manual.atom.io/hacking-atom/sections/package-word-count/